### PR TITLE
chore: remove log.Lazy

### DIFF
--- a/discover/table.go
+++ b/discover/table.go
@@ -309,7 +309,7 @@ func (tab *Table) loadSeedNodes() {
 	tab.mutex.Unlock()
 	for i := range seeds {
 		seed := seeds[i]
-		age := log.Lazy{Fn: func() interface{} { return time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP())) }}
+		age := time.Since(tab.db.LastPongReceived(seed.ID(), seed.IP()))
 		tab.log.Trace("Found seed node in database", "id", seed.ID(), "addr", seed.addr(), "age", age)
 		tab.addSeenNode(seed)
 	}


### PR DESCRIPTION
We have updated the go-ethereum package to interpret the latest network blocks. However, this update leads to an error when using the package:

```
# github.com/waku-org/go-discover/discover
/go/pkg/mod/github.com/waku-org/go-discover@v0.0.0-20240321122731-fe708039d53f/discover/table.go:312:14: undefined: log.Lazy
```

The update was performed in response to the changes made in go-ethereum, as detailed in the following pull request: https://github.com/ethereum/go-ethereum/pull/28622

As a workaround, modified the code accordingly.